### PR TITLE
Fix issue where `get_enum` on EnumField Throws Error

### DIFF
--- a/peewee_extra_fields/__init__.py
+++ b/peewee_extra_fields/__init__.py
@@ -1031,7 +1031,7 @@ class EnumField(SmallIntegerField):
         return member.value
 
     def get_enum(self):
-        return getattr(self.model_class, self.verbose_name)
+        return self.enum
 
     def python_value(self, value):
         enum = self.get_enum()


### PR DESCRIPTION
`get_enum` raises an AttributeError:
```
AttributeError: 'EnumField' object has no attribute 'model_class'
```

This fix will ensure it actually returns the enum class as requested.